### PR TITLE
document correct default daemon uid and gid

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Image: crazymax/msmtpd:latest
 ## Environment variables
 
 * `TZ`: Timezone assigned to the container (default `UTC`)
-* `PUID`: Daemon user id (default `1000`)
-* `PGID`: Daemon group id (default `1000`)
+* `PUID`: Daemon user id (default `1500`)
+* `PGID`: Daemon group id (default `1500`)
 * `SMTP_HOST`: SMTP relay server to send the mail to. **required**
 * `SMTP_PORT`: Port that the SMTP relay server listens on. Default `25` or `465` if TLS.
 * `SMTP_TLS`: Enable or disable TLS (also known as SSL) for secured connections (`on` or `off`).


### PR DESCRIPTION
container-related files all use 1500, update the README accordingly