### PR TITLE
Support allow_from_override setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ linux/s390x
 * `SMTP_PASSWORD`: Set the password for authentication. Authentication must be activated with the `SMTP_AUTH` env var.
 * `SMTP_DOMAIN`: Argument of the `SMTP EHLO` command (default `localhost`)
 * `SMTP_FROM`: Set the envelope-from address. Supported substitution patterns can be found [here](https://marlam.de/msmtp/msmtp.html#Commands-specific-to-sendmail-mode).
+* `SMTP_ALLOW_FROM_OVERRIDE`: Allow configured envelope-from address to be overriden by actual SMTP MAIL FROM . Can be [`on` or `off`](https://marlam.de/msmtp/msmtp.html#Commands-specific-to-sendmail-mode) (default `on`)
 * `SMTP_SET_FROM_HEADER`: When to set a From header. Can be [`auto`, `on` or `off`](https://marlam.de/msmtp/msmtp.html#Commands-specific-to-sendmail-mode) (default `auto`)
 * `SMTP_SET_DATE_HEADER`: When to set a Date header. Can be [`auto` or `off`](https://marlam.de/msmtp/msmtp.html#Commands-specific-to-sendmail-mode) (default `auto`)
 * `SMTP_REMOVE_BCC_HEADERS`: Controls whether to remove Bcc headers. Can be [`on` or `off`](https://marlam.de/msmtp/msmtp.html#Commands-specific-to-sendmail-mode) (default `on`)

--- a/rootfs/etc/cont-init.d/02-config.sh
+++ b/rootfs/etc/cont-init.d/02-config.sh
@@ -71,6 +71,7 @@ if [ -n "$SMTP_USER" ];                     then echo "user $SMTP_USER" >> /etc/
 if [ -n "$SMTP_PASSWORD" ];                 then echo "password $SMTP_PASSWORD" >> /etc/msmtprc; fi
 if [ -n "$SMTP_DOMAIN" ];                   then echo "domain $SMTP_DOMAIN" >> /etc/msmtprc; fi
 if [ -n "$SMTP_FROM" ];                     then echo "from $SMTP_FROM" >> /etc/msmtprc; fi
+if [ -n "$SMTP_ALLOW_FROM_OVERRIDE" ];      then echo "allow_from_override $SMTP_ALLOW_FROM_OVERRIDE" >> /etc/msmtprc; fi
 if [ -n "$SMTP_SET_FROM_HEADER" ];          then echo "set_from_header $SMTP_SET_FROM_HEADER" >> /etc/msmtprc; fi
 if [ -n "$SMTP_SET_DATE_HEADER" ];          then echo "set_date_header $SMTP_SET_DATE_HEADER" >> /etc/msmtprc; fi
 if [ -n "$SMTP_REMOVE_BCC_HEADERS" ];       then echo "remove_bcc_headers $SMTP_REMOVE_BCC_HEADERS" >> /etc/msmtprc; fi


### PR DESCRIPTION
Thanks a lot for this great image.

This adds support for the allow_from_override setting as also requested in https://github.com/crazy-max/docker-msmtpd/issues/77