### PR TITLE
fix msmtpd child reaping

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,18 @@ jobs:
           log_check: "[services.d] done"
           timeout: 120
       -
+        name: Check container health
+        run: |
+          for i in $(seq 1 60); do
+            status=$(docker inspect --format "{{.State.Health.Status}}" "$CONTAINER_NAME")
+            if [ "$status" = "healthy" ]; then
+              exit 0
+            fi
+            sleep 2
+          done
+          docker inspect --format "{{json .State.Health}}" "$CONTAINER_NAME"
+          exit 1
+      -
         name: Logs
         if: always()
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ ARG MSMTP_VERSION
 WORKDIR /src
 RUN curl -sSL "https://marlam.de/msmtp/releases/msmtp-$MSMTP_VERSION.tar.xz" | tar xJv --strip 1
 COPY patches /patches
-RUN patch -p1 < /patches/base64-stdbool.patch
+RUN patch -p1 < /patches/base64-stdbool.patch \
+  && patch -p1 < /patches/msmtpd-reap-children.patch
 
 FROM base AS builder
 ARG TARGETPLATFORM
@@ -56,4 +57,4 @@ COPY rootfs /
 EXPOSE 2500
 
 HEALTHCHECK --interval=10s --timeout=5s \
-  CMD echo EHLO localhost | nc 127.0.0.1 2500 | grep 250 || exit 1
+  CMD printf 'EHLO localhost\r\nQUIT\r\n' | nc -w 2 127.0.0.1 2500 | grep -q '^250' || exit 1

--- a/patches/msmtpd-reap-children.patch
+++ b/patches/msmtpd-reap-children.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: CrazyMax <1951866+crazy-max@users.noreply.github.com>
+Date: Mon, 13 Jul 2026 17:48:00 +0200
+Subject: [PATCH] Fix msmtpd child process reaping
+
+SIGCHLD signals may be coalesced when several SMTP session children exit
+around the same time. Reap all available children each time the handler runs
+so the active session count does not drift and prevent new connections from
+being accepted.
+
+Signed-off-by: CrazyMax <1951866+crazy-max@users.noreply.github.com>
+---
+ src/msmtpd.c | 24 +++++++++++++-----------
+ 1 file changed, 13 insertions(+), 11 deletions(-)
+
+diff --git a/src/msmtpd.c b/src/msmtpd.c
+--- a/src/msmtpd.c
++++ b/src/msmtpd.c
+@@ -639,18 +639,20 @@ void sigchld_action(int signum, siginfo_t* si, void* ucontext)
+ {
+     (void)signum;   /* unused */
+     (void)ucontext; /* unused */
++    (void)si;       /* unused */
+     int wstatus;
+-    if (waitpid(si->si_pid, &wstatus, 0) == si->si_pid) {
+-        int child_exit_status = -1;
+-        if (WIFEXITED(wstatus))
+-            child_exit_status = WEXITSTATUS(wstatus);
+-        if (child_exit_status >= 2) {
+-            struct timespec tp;
+-            clock_gettime(CLOCK_MONOTONIC, &tp);
+-            last_auth_failure_time = tp.tv_sec;
+-            auth_failure_occurred = 1;
++    pid_t pid;
++    while ((pid = waitpid(-1, &wstatus, WNOHANG)) > 0) {
++        int child_exit_status = -1;
++        if (WIFEXITED(wstatus))
++            child_exit_status = WEXITSTATUS(wstatus);
++        if (child_exit_status >= 2) {
++            struct timespec tp;
++            clock_gettime(CLOCK_MONOTONIC, &tp);
++            last_auth_failure_time = tp.tv_sec;
++            auth_failure_occurred = 1;
+         }
+-        active_sessions_count--;
+-    }
++        active_sessions_count--;
++    }
+ }
+
+ /* Parse the command line */


### PR DESCRIPTION
fixes #85 
relates to https://github.com/marlam/msmtp/issues/227

This fixes a long-running `msmtpd` failure mode where short-lived SMTP sessions can leave zombie child processes behind and eventually cause the daemon to stop accepting new connections.

`SIGCHLD` signals can be coalesced when multiple session children exit close together. If only one child is reaped, `active_sessions_count` can drift upward while zombie children remain, which can explain the downstream reports of the container becoming unhealthy and no longer relaying mail after running for days.